### PR TITLE
feat: Implement full broadcast feature for admin

### DIFF
--- a/src/handlers/commands.ts
+++ b/src/handlers/commands.ts
@@ -480,6 +480,7 @@ export class CommandHandler {
       inline_keyboard: [
         [
           { text: "📊 آمار ربات", callback_data: "admin:stats" },
+          { text: "📢 ارسال پیام همگانی", callback_data: "admin:broadcast" }
         ],
         [
           { text: "↩️ بازگشت به منوی اصلی", callback_data: "menu:help" },

--- a/src/services/telegram.ts
+++ b/src/services/telegram.ts
@@ -115,14 +115,24 @@ export class TelegramService {
    */
   async sendDocument(
     chatId: string | number, 
-    documentBuffer: ArrayBuffer, 
+    document: ArrayBuffer | string,
     filename: string, 
     caption?: string, 
     replyMarkup?: InlineKeyboardMarkup
   ): Promise<TelegramApiResponse> {
+    if (typeof document === 'string') {
+        const payload: Record<string, any> = {
+            chat_id: String(chatId),
+            document: document,
+        };
+        if (caption) payload.caption = caption;
+        if (replyMarkup) payload.reply_markup = replyMarkup;
+        return await this.apiCall("sendDocument", payload);
+    }
+
     const form = new FormData();
     form.append("chat_id", String(chatId));
-    form.append("document", new Blob([documentBuffer], { type: "application/pdf" }), filename);
+    form.append("document", new Blob([document], { type: "application/pdf" }), filename);
     
     if (caption) form.append("caption", caption);
     if (replyMarkup) form.append("reply_markup", JSON.stringify(replyMarkup));
@@ -167,10 +177,58 @@ export class TelegramService {
     return await this.apiCall<TelegramMessage>("forwardMessage", payload);
   }
 
+  async sendPhoto(chatId: string | number, photo: string, caption?: string): Promise<TelegramApiResponse<TelegramMessage>> {
+    const payload = {
+      chat_id: String(chatId),
+      photo: photo,
+      caption: caption,
+    };
+    return await this.apiCall<TelegramMessage>("sendPhoto", payload);
+  }
+
+  async sendVideo(chatId: string | number, video: string, caption?: string): Promise<TelegramApiResponse<TelegramMessage>> {
+    const payload = {
+      chat_id: String(chatId),
+      video: video,
+      caption: caption,
+    };
+    return await this.apiCall<TelegramMessage>("sendVideo", payload);
+  }
+
+  async sendAudio(chatId: string | number, audio: string, caption?: string): Promise<TelegramApiResponse<TelegramMessage>> {
+    const payload = {
+      chat_id: String(chatId),
+      audio: audio,
+      caption: caption,
+    };
+    return await this.apiCall<TelegramMessage>("sendAudio", payload);
+  }
+
+  async sendVoice(chatId: string | number, voice: string, caption?: string): Promise<TelegramApiResponse<TelegramMessage>> {
+    const payload = {
+      chat_id: String(chatId),
+      voice: voice,
+      caption: caption,
+    };
+    return await this.apiCall<TelegramMessage>("sendVoice", payload);
+  }
+
   /**
    * Gets bot information
    */
   async getBotInfo(): Promise<TelegramApiResponse<BotInfo>> {
     return await this.apiCall<BotInfo>("getMe");
+  }
+
+  /**
+   * Deletes a message
+   */
+  async deleteMessage(chatId: string | number, messageId: number): Promise<TelegramApiResponse> {
+    const payload = {
+      chat_id: String(chatId),
+      message_id: messageId,
+    };
+
+    return await this.apiCall("deleteMessage", payload);
   }
 }


### PR DESCRIPTION
This commit introduces a comprehensive broadcast feature for the bot's admin. The feature is accessible through the /admin command and allows the admin to send any type of message to various audiences.

Key Features:
- Multi-step guided flow for creating and sending broadcasts.
- Send as a forwarded message from the admin or directly as the bot.
- Target audiences: all users, all groups, both, or a specific list of chat IDs.
- Preview of the message before sending.
- Confirmation steps before the broadcast is sent.
- Real-time progress updates during the broadcast.
- A final report with success/failure counts and duration.
- Ability to delete the last sent broadcast or select multiple previous broadcasts for deletion.
- New database tables (`broadcasts` and `broadcast_messages`) to log sent messages and facilitate deletion.

The implementation includes robust error handling and state management to ensure a smooth user experience for the admin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Admin “Broadcast” panel with guided, multi-step flow.
  * Choose delivery method (forward/bot) and audience (all users, all groups, both, or specific IDs/usernames).
  * Supports text, photo, video, document, audio, and voice.
  * Preview message and confirm before sending.
  * Live progress updates and final delivery report.

* Improvements
  * Delete last broadcast or select and delete multiple past broadcasts from the admin UI.
  * Safer, admin-only access with clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->